### PR TITLE
Fixed TypeError: nnot destructure property 'children' of '_ref' as it…

### DIFF
--- a/src/components/imageList/ImagesList.js
+++ b/src/components/imageList/ImagesList.js
@@ -6,7 +6,7 @@ import Options from "./Options";
 import { Avatar, Tooltip, Typography } from "@mui/material";
 import moment from "moment/moment";
 import useFirestore from "../../firebase/useFirestore";
-import useAuth from "../../context/AuthContext";
+import {useAuth} from "../../context/AuthContext";
 
 function srcset(image, size, rows = 1, cols = 1) {
   return {

--- a/src/components/upload/Form.js
+++ b/src/components/upload/Form.js
@@ -1,7 +1,7 @@
 import { AddAPhoto } from "@mui/icons-material";
 import { Fab, Input } from "@mui/material";
 import React from "react";
-import useAuth from '../../context/AuthContext';
+import {useAuth} from '../../context/AuthContext';
 import Login from '../../components/user/Login';
 
 const Form = ({ setFiles }) => {


### PR DESCRIPTION
## **Description**
Had a TypeError: Cannot destructure property 'children' of '_ref' as it is undefined.
 
Expected/correct: import {useAuth} from both files;

Reason: useAuth is not a default export.

## Type of Change
- [x] Bug

## Testing
 - [x] Running the code
- [ ]  Unit Testing
- [ ]  Integrated Testing

## **Checklist / Tasks**
- [x]  Corrected the import of useAuth in both ImageList and Form files.